### PR TITLE
Add RStudio project file, remove debug output

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/R/peptide-mhc.R
+++ b/R/peptide-mhc.R
@@ -20,7 +20,6 @@ NULL
 #'
 #' @export
 supportedMHCs <- function( l=NULL ){
-	print( getPackageName() )
 	r <- read.table( system.file( "extdata", "model_list.txt", package=getPackageName() ),
 		as.is=TRUE )$V1
 	mhcname <- gsub( '-[0-9][0-9]?$', '', r )

--- a/epitope-prediction.Rproj
+++ b/epitope-prediction.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/vignettes/epitope-prediction-using-r.Rmd
+++ b/vignettes/epitope-prediction-using-r.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteIndexEntry{Peptide-MHC Binding Prediction Using R}
   \usepackage[utf8]{inputenc} 
 output:
-  pdf_document:
+  knitr:::html_vignette:
     toc: yes
 ---
 

--- a/vignettes/epitope-prediction-using-r.Rmd
+++ b/vignettes/epitope-prediction-using-r.Rmd
@@ -7,7 +7,7 @@ vignette: >
   %\VignetteIndexEntry{Peptide-MHC Binding Prediction Using R}
   \usepackage[utf8]{inputenc} 
 output:
-  knitr:::html_vignette:
+  pdf_document:
     toc: yes
 ---
 


### PR DESCRIPTION
Hi Dr. Textor,

I've added an RStudio project file, allowing users to open up `epitope-prediction` from RStudio easily. RStudio is the IDE most used in R development, thus one can expect most users use it. The `.gitignore` and `.Rbuildignore` help to maintain a clean repo and build.

Do you agree this is a good idea to add?

Additionally, I've removed a print statement, which was probably a left-over from some debugging.

Cheers, Richel Bilderbeek